### PR TITLE
Add "open in new" icon to help button

### DIFF
--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -30,7 +30,10 @@
 	<span class="setting_menu_button selected" onclick="show_setting_menu(this);">Home</span>
 	<span class="setting_menu_button" onclick="show_setting_menu(this);">Settings</span>
 	<span class="setting_menu_button" onclick="show_setting_menu(this);">Interface</span>
-	<span style="float: right;margin-right: 30px;" onclick="window.open('https://github.com/KoboldAI/KoboldAI-Client/wiki');">Help</span>
+	<span style="float: right;margin-right: 30px;padding: 0px 10px;" onclick="window.open('https://github.com/KoboldAI/KoboldAI-Client/wiki');">
+		Help
+		<icon class="material-icons-outlined" style="font-size:14px;position:relative;top:2px;">open_in_new</icon>
+	</span>
 </div>
 <div class="flyout_menu_contents">
 


### PR DESCRIPTION
it's now obvious that this button opens a new browser tab instead of switching to a kobold tab

![image](https://user-images.githubusercontent.com/69319754/186529886-9668e2bd-272e-41cd-86de-0a4c45f190b8.png)