### PR TITLE
Set palette to #000000 in Gruvbox Dark

### DIFF
--- a/themes/Gruvbox Dark.css
+++ b/themes/Gruvbox Dark.css
@@ -128,21 +128,21 @@
 
 	--help_icon: var(--gruvbox-light0);
 	--help_icon_text: #282c2c;
-    --tooltip_text:var(--on_secondary_palette);
+    --tooltip_text:var(--gruvbox-light0);
     --tooltip_background:var(--secondary_palette);
 
 	/* World Info */
 	--wi_card_border_color: var(--gruvbox-dark3);
-    --wi_card_border_color_to_ai:var(--on_secondary_palette);
+    --wi_card_border_color_to_ai:var(--gruvbox-light0);
 
     --wi_card_bg_color: var(--gruvbox-dark0);
-	--wi_card_text_color:var(--on_primary_palette);
+	--wi_card_text_color:var(--gruvbox-light0);
 
     --wi_card_tag_bg_color: var(--gruvbox-dark0);
-	--wi_card_tag_text_color: var(--on_primary_palette);
+	--wi_card_tag_text_color: var(--gruvbox-light0);
 	
     --wi_tag_color: var(--gruvbox-neutral-blue);
-	--wi_tag_text_color:var(--on_primary_containter_palette);
+	--wi_tag_text_color:var(--gruvbox-light0);
 	--wi_folder_background: var(--gruvbox-dark0);
 	
 	/* Popup */

--- a/themes/Gruvbox Dark.css
+++ b/themes/Gruvbox Dark.css
@@ -47,25 +47,25 @@
 	--main_accent: var(--gruvbox-neutral-purple);
 
 	/* Palette */
-	--primary_palette: #afc6ff;
+	--primary_palette: #000000;
 	--on_primary_palette: var(--gruvbox-light0);
-	--primary_containter_palette: #004397;
-	--on_primary_containter_palette: #d9e2ff;
+	--primary_containter_palette: #000000;
+	--on_primary_containter_palette: #000000;
 
-	--secondary_palette: #f7c5ee;
-	--on_secondary_palette: #5c0059;
-	--secondary_container_palette: #d663bd;
-	--on_secondary_container_palette: #4e0039;
+	--secondary_palette: #000000;
+	--on_secondary_palette: #000000;
+	--secondary_container_palette: #000000;
+	--on_secondary_container_palette: #000000;
 
-	--tertiary_palette: #a8d473;
-	--on_tertiary_palette: #1f3700;
-	--tertiary_container_palette: #2f4f00;
-	--on_tertiary_container_palette: #c3f18c; 
+	--tertiary_palette: #000000;
+	--on_tertiary_palette: #000000;
+	--tertiary_container_palette: #000000;
+	--on_tertiary_container_palette: #000000; 
 
-	--error_palette: var(--gruvbox-bright-purple);
-	--on_error_palette: var(--gruvbox-neutral-red);
-	--error_container_palette: var(--gruvbox-faded-red);
-	--on_error_container_palette: var(--gruvbox-bright-purple);
+	--error_palette: #000000;
+	--on_error_palette: #000000;
+	--error_container_palette: #000000;
+	--on_error_container_palette: #000000;
 
 	--background_palette: var(--gruvbox-dark0-soft);
 	--on_background_palette: var(--gruvbox-light0);


### PR DESCRIPTION
As per GuiAworld's request, themes that do not make use of the palette system should set their palette colors to black.