### PR TITLE
WI Extra data hack

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -258,7 +258,7 @@ app.secret_key = secrets.token_hex()
 app.config['SESSION_TYPE'] = 'filesystem'
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 Session(app)
-socketio = SocketIO(app, async_method="eventlet", manage_session=False, cors_allowed_origins='*')
+socketio = SocketIO(app, async_method="eventlet", manage_session=False, cors_allowed_origins='*', max_http_buffer_size=10_000_000)
 #socketio = SocketIO(app, async_method="eventlet", manage_session=False, cors_allowed_origins='*', logger=True, engineio_logger=True)
 koboldai_vars = koboldai_settings.koboldai_vars(session, socketio)
 


### PR DESCRIPTION
SocketIO normally has a buffer size of 1MB, but here we set it to 10MB to load bigger world info files. This is a temporary patch for a larger problem that will take some work to solve.