### PR TITLE
Textedit betterness

### DIFF
--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -1188,8 +1188,8 @@ body {
   display: none;
 }
 
-[contenteditable="true"]:active,
-[contenteditable="true"]:focus{
+[contenteditable="true"] .chunk:active,
+[contenteditable="true"] .chunk:focus {
   border:none;
   outline:none;
   color: var(--text_edit);

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -272,6 +272,7 @@ function do_story_text_updates(data) {
 		span.classList.add("rawtext");
 		span.classList.add("chunk");
 		span.chunk = data.value.id;
+		span.setAttribute("tabindex", 0);
 		span.original_text = data.value.action['Selected Text'];
 		story_area.oldChunks.push(data.value.id);
 

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -275,17 +275,6 @@ function do_story_text_updates(data) {
 		span.original_text = data.value.action['Selected Text'];
 		story_area.oldChunks.push(data.value.id);
 
-		/*
-		span.setAttribute("contenteditable", true);
-		span.onblur = function () {
-			if (this.textContent != this.original_text) {
-				socket.emit("Set Selected Text", {"id": this.chunk, "text": this.textContent});
-				this.original_text = this.textContent;
-				this.classList.add("pulse");
-			}
-		}
-		*/
-
 		span.onkeydown = detect_enter_text;
 		new_span = document.createElement("span");
 		new_span.textContent = data.value.action['Selected Text'];
@@ -1378,7 +1367,6 @@ function load_model() {
 }
 
 function world_info_entry_used_in_game(data) {
-	console.info(data, world_info_data)
 	world_info_data[data.uid]['used_in_game'] = data['used_in_game'];
 	world_info_card = document.getElementById("world_info_"+data.uid);
 	if (data.used_in_game) {
@@ -3732,8 +3720,6 @@ $(document).ready(function(){
 		for (const chunkID of gameText.oldChunks) {
 			const chunk = document.getElementById(`Selected Text Chunk ${chunkID}`);
 			if (!chunk) {
-				console.log("Deleted", chunkID)
-
 				socket.emit("Set Selected Text", {
 					id: chunkID,
 					text: "",

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3724,8 +3724,6 @@ $(document).ready(function(){
 					id: chunkID,
 					text: "",
 				});
-
-				assign_world_info_to_action(item, null);
 			}
 		}
 

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -6,7 +6,7 @@
 		var debug_info = {errors: []};
 
 		window.addEventListener('error', function(event) {
-			debug_info.push({msg: message, url: url, line: line});
+			debug_info.errors.push({msg: event.message, url: event.filename, line: event.lineno});
 		});
 	</script>
 	<script type="module">import {encode, decode} from "./static/tokenizer.js";window.encode = encode;window.decode = decode;</script>

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -47,7 +47,7 @@
 		<!------------ Game Text Screen--------------------->
 		<div class="gamescreen" id="gamescreen">
 			<div id="disconnect_message"><center><h1>Disconnected</h1></center></div>
-			<div class="gametext" id="Selected Text">
+			<div class="gametext" id="Selected Text" contenteditable="true">
 				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_length var_sync_alt_story_prompt_in_ai rawtext" contenteditable=true onblur="if (getAttribute(this, 'old_text') != this.textContent) {sync_to_server(this);}" onkeydown="detect_enter_text"></span>
 				<span id="Delete Me">
 					&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
When each chunk is treated as a `contenteditable`, it prevents selecting and editing multi-chunk blocks of checks and overall makes editing a pain. This PR makes each chunk not `contenteditable`, instead opting to make the parent, `Selected Text`, `contenteditable`. This means we now send text edits on the `Selected Text`'s `blur` event instead of each chunk individually handling events. Fixes #120.

**Note:** This change breaks the "currently edited text" color. I've implemented a hack that works unreliably, but we should really get the correct chunk to highlight via caret position.