### PR TITLE
Enabled text to image generations from the prompt using the Stable Horde

### DIFF
--- a/environments/finetuneanon.yml
+++ b/environments/finetuneanon.yml
@@ -19,6 +19,7 @@ dependencies:
   - marshmallow>=3.13
   - apispec-webframeworks
   - loguru
+  - Pillow
   - pip:
     - git+https://github.com/finetuneanon/transformers@gpt-neo-localattention3-rp-b
     - flask-cloudflared

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -20,6 +20,7 @@ dependencies:
   - marshmallow>=3.13
   - apispec-webframeworks
   - loguru
+  - Pillow
   - pip:
     - flask-cloudflared
     - flask-ngrok

--- a/environments/rocm-finetune.yml
+++ b/environments/rocm-finetune.yml
@@ -15,6 +15,7 @@ dependencies:
   - marshmallow>=3.13
   - apispec-webframeworks
   - loguru
+  - Pillow
   - pip:
     - --find-links https://download.pytorch.org/whl/rocm4.2/torch_stable.html
     - torch

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -17,6 +17,7 @@ dependencies:
   - marshmallow>=3.13
   - apispec-webframeworks
   - loguru
+  - Pillow
   - pip:
     - --find-links https://download.pytorch.org/whl/rocm4.2/torch_stable.html
     - torch==1.10.*

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -705,7 +705,11 @@ class user_settings(settings):
         self.output_streaming = True
         self.show_probs = False # Whether or not to show token probabilities
         self.beep_on_complete = False
-        
+        self.sh_apikey   = ""     # API key to use for txt2img from the Stable Horde.
+        self.text2img    = False  # If set to true, will create image generations based on the player's prompt
+        # Text to append to the end of a prompt, to specify artistic direction. It is always prepended by ', ' 
+        # Example: "fantasy illustration, artstation, by jason felix by steve argyle by tyler jacobson by peter mohrbacher, cinematic lighting"
+        self.art_direction   = ""
         
     def __setattr__(self, name, value):
         new_variable = name not in self.__dict__


### PR DESCRIPTION
This adds the functionality of generating images automatically based on the prompt

I've added two new args in the parser and three new variables in your `koboldai_vars`.

* `sh_apikey`: the API key to use for the Stable Horde. As usual, 0000000000 is Anon, but the player can extract their own
* `text2img`: if True, then a thread will be started during generations which will also generate an image from the prompt
* `art_direction`: This one doesn't have an arg to set. It should be done via the GUI. It will give a direction to SD to know how to style the art.

These three arguments need to be able to be set via the GUI. Furthermore, we also need a way and a place to actually display the image created in the GUI. Currently the code simply saves the generated image as story_art.png, but it shouldn't be too hard to send the image with a message to be displayed.

The relevant function doing all this is `text2img()`

Another important part is, we need to figure a good approach to limit the amount of prompt sent to Stable Diffusion, as it's not as good at parsing tons of text. Perhaps make it only send the "significant" part of the prompt? But I would have no idea how to do that. But that can also come later as it's pretty decent even with a full prompt. 