### PR TITLE
Fix requesting a lower batch count than numseqs

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -2163,6 +2163,9 @@ def patch_transformers():
             scores: torch.FloatTensor,
             **kwargs,
         ) -> bool:
+            if not koboldai_vars.inference_config.do_core:
+                return False
+
             koboldai_vars.generated_tkns += 1
 
             if (
@@ -5006,7 +5009,7 @@ def calcsubmit(txt):
         # Send it!
         ikrequest(subtxt)
 
-def core_generate(text: list, min: int, max: int, found_entries: set):
+def core_generate(text: list, min: int, max: int, found_entries: set, is_core: bool = False):
     # This generation function is tangled with koboldai_vars intentionally. It
     # is meant for the story and nothing else.
 
@@ -5065,6 +5068,7 @@ def core_generate(text: list, min: int, max: int, found_entries: set):
                 batch_count=numseqs,
                 # Real max length is handled by CoreStopper.
                 bypass_hf_maxlength=True,
+                is_core=True,
             )
 
             genout = result.encoded
@@ -5192,9 +5196,11 @@ def raw_generate(
     do_dynamic_wi: bool = False,
     batch_count: int = 1,
     bypass_hf_maxlength: bool = False,
-    generation_settings: Optional[dict] = None
+    generation_settings: Optional[dict] = None,
+    is_core: bool = False
 ) -> GenerationResult:
 
+    koboldai_vars.inference_config.do_core = is_core
     gen_settings = GenerationSettings(*(generation_settings or {}))
 
     model_functions = {

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1001,6 +1001,7 @@ class system_settings(settings):
             do_dynamic_wi: bool = False
             # Genamt stopping is mostly tied to Dynamic WI
             stop_at_genamt: bool = False
+            do_core: bool = True
         self.inference_config = _inference_config()
         
         self._koboldai_var = koboldai_var


### PR DESCRIPTION
Previously, we would run `CoreStopper` for non-core generations. This caused things like the inference scratchpad to fail when `genseqs` was higher than 1.