### PR TITLE
Make tooltips better

### DIFF
--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -5048,8 +5048,17 @@ let load_substitutions;
 
 	document.addEventListener("mousemove", function(event) {
 		if (!tooltipActive) return;
-		tooltip.style.left = `${event.x}px`;
-		tooltip.style.top = `${event.y}px`;
+
+		let [x, y] = [event.x, event.y];
+
+		// X + the tooltip's width is the farthest point right we will display;
+		// let's account for it. If we will render outside of the window,
+		// subtract accordingly.
+		let xOverflow = (x + tooltip.clientWidth) - window.innerWidth;
+		if (xOverflow > 0) x -= xOverflow;
+
+		tooltip.style.left = `${x}px`;
+		tooltip.style.top = `${y}px`;
 	});
 
 	// Inital scan

--- a/templates/popups.html
+++ b/templates/popups.html
@@ -18,12 +18,12 @@
 		</span>--->
 		<span>
 			<button class="settings_button" id="upload_without_save_button" onclick="document.getElementById('upload_without_save').click()">
-				<span class="material-icons-outlined cursor" title="Load from Local">browser_updated</span>
+				<span class="material-icons-outlined cursor" tooltip="Load from Local">browser_updated</span>
 				<span class="button_label">Load from Local</span>
 			</button>
 			<input class="hidden" type=file  id="upload_without_save" onchange="upload_file_without_save(this)">
 			<button id="import_story_button" class="settings_button hidden" onclick="document.getElementById('import_aidg_club_popup').classList.remove('hidden');">
-				<span class="material-icons-outlined cursor" title="Import Story">cloud_download</span>
+				<span class="material-icons-outlined cursor" tooltip="Import Story">cloud_download</span>
 				<span class="button_label">Import Story</span>
 			</button>
 		</span>
@@ -52,7 +52,7 @@
 		</div>
 		<div class="hidden" id=modellayers>
 			<div class="justifyleft">
-				GPU/Disk Layers<span class="material-icons-outlined helpicon" title="Number of layers to assign to GPUs and to disk cache. Remaining layers will be put into CPU RAM.">help_icon</span>
+				GPU/Disk Layers<span class="material-icons-outlined helpicon" tooltip="Number of layers to assign to GPUs and to disk cache. Remaining layers will be put into CPU RAM.">help_icon</span>
 			</div>
 			<div class="justifyright"><span id="gpu_layers_current">0</span>/<span id="gpu_layers_max">0</span></div>
 			<div id=model_layer_bars style="color: white"></div>


### PR DESCRIPTION
This pr fixes tooltips so that they:
- shift around as needed around window borders
- find tooltip attributes with more accuracy
- are applied to everything we used to use title on before (barring the preset selector; that will have to be redone as a custom element)