### PR TITLE
Make attention bias generic and add option to apply it to author's note

### DIFF
--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -241,7 +241,8 @@ class koboldai_vars(object):
         if len(memory_tokens) != 0:
             context.append({"type": "memory", 
                             "text": "".join([x[1] for x in memory_data]), 
-                            "tokens": memory_data})
+                            "tokens": memory_data,
+                            "attention_multiplier": self.memory_attn_bias})
             used_tokens += len(memory_tokens)
         
         
@@ -350,7 +351,7 @@ class koboldai_vars(object):
 
             #Add our author's note if we've hit andepth
             if not inserted_author_note and len(actions_seen) >= self.andepth and self.authornote != "":
-                game_context.insert(0, {"type": "authors_note", "text": authors_note_text, "tokens": authors_note_data})
+                game_context.insert(0, {"type": "authors_note", "text": authors_note_text, "tokens": authors_note_data, "attention_multiplier": self.an_attn_bias})
                 inserted_author_note = True
 
             action_data = [[x, self.tokenizer.decode(x)] for x in self.tokenizer.encode(action_text_split[i][0])]
@@ -426,7 +427,7 @@ class koboldai_vars(object):
         ######################################### Verify Author's Note Data in AI Text ########################################################
         #if we don't have enough actions to get to author's note depth then we just add it right before the game text
         if not inserted_author_note and self.authornote != "":
-            game_context.insert(0, {"type": "authors_note", "text": authors_note_text, "tokens": authors_note_data})
+            game_context.insert(0, {"type": "authors_note", "text": authors_note_text, "tokens": authors_note_data, "attention_multiplier": self.an_attn_bias})
         
         
         ######################################### Add our prompt data ########################################################
@@ -783,6 +784,7 @@ class story_settings(settings):
 
         # bias experiment
         self.memory_attn_bias = 1
+        self.an_attn_bias = 1
         
     def save_story(self):
         if not self.no_save:

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -24,7 +24,7 @@
 		<icon class="material-icons-outlined" style="font-size:14px;position:relative;top:2px;">open_in_new</icon>
 	</span>
 </div>
-<span class="material-icons-outlined cursor search_icon" tooltip="Search Settings" onclick="open_finder();">search</span>
+<span class="material-icons-outlined cursor search_icon" tooltip="Finder" onclick="open_finder();">search</span>
 <div class="flyout_menu_contents">
 
 	<div id="setting_menu_home" class="settings_category_area tab-target tab-target-settings">

--- a/templates/story flyout.html
+++ b/templates/story flyout.html
@@ -13,18 +13,18 @@
 			</div>
 			<textarea rows=20 id="memory" class="var_sync_story_memory var_sync_alt_story_memory_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off"></textarea>
 
-			<div id="Attention-Bias" class="var_sync_alt_system_experimental_features">
-				<h4 class="section_header"><label for="Attention-Bias">Attention Bias Test</label></h4>
+			<div id="Mem-Attention-Bias" class="var_sync_alt_system_experimental_features">
+				<h4 class="section_header"><label for="Mem-Attention-Bias">Attention Bias Test</label></h4>
 				<span class="help_text">
 					<b>Note: This only works on OPT models for now! Patches will be written for other models once it's known this actually has a positive effect. Upon first use of this bias, you should see "Applying attention bias" in the console.</b><br>
 					This setting <i>may</i> change how the AI pays attention to memory. Any high number in the ballpark of 15 may cause incoherence. The option to select higher numbers is present for experimentation.
 				</span>
-				<input type="range" oninput="memAttn(this.value);" onchange="sync_to_server(this);" class="var_sync_story_memory_attn_bias sync_as_float" value="1" min="1" max="50" step="0.1"></input>
+				<input type="range" oninput="memAttnInput(this.value);" onchange="sync_to_server(this);" class="var_sync_story_memory_attn_bias sync_as_float" value="1" min="1" max="50" step="0.1"></input>
 				<span id="memattnbiaslabel">1</span>
 				<script>
-					const label = document.querySelector("#memattnbiaslabel");
-					function memAttn(val) {
-						label.innerText = val;
+					const memAttn = document.querySelector("#memattnbiaslabel");
+					function memAttnInput(val) {
+						memAttn.innerText = val;
 					}
 				</script>
 			</div>
@@ -49,6 +49,20 @@
 			<input autocomplete="off" id=authors_notes_template type=text class="var_sync_story_authornotetemplate fullwidth" onchange='sync_to_server(this);'><br/>
 			<label for="authors_notes">Author's Notes:</label><br/>
 			<textarea autocomplete="off" rows=16 id="authors_notes" class="var_sync_story_authornote var_sync_alt_story_authornote_length fullwidth" oninput="autoResize(this)" onchange='sync_to_server(this);'></textarea><br/>
+
+			<div id="An-Attention-Bias" class="var_sync_alt_system_experimental_features">
+				<h4 class="section_header"><label for="An-Attention-Bias">Attention Bias Test</label></h4>
+				<span class="help_text">See disclaimer in memory page.</span>
+				<input type="range" oninput="anAttnInput(this.value);" onchange="sync_to_server(this);" class="var_sync_story_an_attn_bias sync_as_float" value="1" min="1" max="50" step="0.1"></input>
+				<span id="anattnbiaslabel">1</span>
+				<script>
+					const anAttn = document.querySelector("#anattnbiaslabel");
+					function anAttnInput(val) {
+						anAttn.innerText = val;
+					}
+				</script>
+			</div>
+
 			<div class="setting_tile_area">
 				{% with menu='author_notes' %}
 					{% with sub_path='' %}


### PR DESCRIPTION
As attention bias seems to be working somewhat, I have made it easy-ish to apply to any context chunk internally, and added support for author's note.

Attention bias could be improved significantly on the model side of things. One thing I can think of is that we apply the attention bias globally with no regard to what types of patterns each attention head has learned to attend to; if we universally apply the attention multiplication on an attention head which has learned to do something like recognize which subject a verb belongs to, our naive implementation will blindly interfere with these relations, resulting in problems ranging from slight mistakes to incoherence. The same could be said about attention heads which specialize in relations tied to token distance. We may be able to work around this by only applying the bias if the attention score for a token in that head is over a certain threshold. The ideal solution would probably be to automatically perform some sort of analysis on the attention heads, but idk how that would work. Hopefully attention bias will get easier to debug once i get around to making an attention viewer