### PR TITLE
Notifications

### DIFF
--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -2449,6 +2449,87 @@ body {
 	border-radius: 3px;
 }
 
+/* Notifcations */
+#notification-container {
+	position: absolute;
+	top: 15px;
+	right: 0px;
+	height: calc(100vh - 15px);
+	width: 400px;
+	z-index: 8;
+	pointer-events: none;
+	overflow-y: hidden;
+	overflow-x: hidden;
+	transition: 200ms top;
+}
+
+.notification {
+	z-index: 8;
+	background-color: #30414e;
+	animation: 10s 1 alternate swoosh-in;
+	margin-right: 15px;
+	overflow: hidden;
+	pointer-events: all;
+	margin-bottom: 15px;
+	left: 110%;
+}
+
+.notification.notification-error {
+	background-color: #4e3030;
+}
+
+@keyframes swoosh-in {
+	from {
+		transform: translateX(110%);
+	}
+
+	5% {
+		transform: translateX(0%);
+	}
+
+	95% {
+		transform: translateX(0%);
+	}
+
+	to {
+		transform: translateX(110%);
+	}
+}
+
+.notification .notif-text {
+	margin: 5px;
+}
+
+.notification .notif-title {
+	color: #6f96b1;
+	display: block;
+	font-weight: bold;
+}
+
+.notification.notification-error .notif-title {
+	color: #b16f6f;
+}
+
+.notification .notif-body {
+	display: block;
+}
+
+.notification .notif-bar {
+	background-color: #407497;
+	height: 3px;
+	width: 100%;
+	animation: 10s 1 alternate shrink-away;
+}
+
+.notification.notification-error .notif-bar {
+	background-color: #974040;
+}
+
+@keyframes shrink-away {
+  from { width: 100%; }
+  to { width: 0%; }
+}
+
 /*---------------------------------- Global ------------------------------------------------*/
 .hidden {
 	display: none;

--- a/templates/popups.html
+++ b/templates/popups.html
@@ -268,3 +268,5 @@
 		</div>
 	</div>
 </div>
+
+<div id="notification-container"></div>


### PR DESCRIPTION
This pull request adds notifications that fly out from the top right of the screen, show a shrinking bar to indicate lifetime, and finally shrivel back whence they came. They are designed to be used to inform the user or report small errors, where previously we did not provide visual feedback. The more intrusive error popup is left to handle critical and fatal errors.

An error notification:
![image](https://user-images.githubusercontent.com/69319754/198464741-699e94e5-b9d6-41f4-a0be-e958faca7baa.png)
And a standard notification (unused for now):
![image](https://user-images.githubusercontent.com/69319754/198471378-72a168b1-b33f-46a3-8b09-a1bd3c7ffc74.png)
