### PR TITLE
Fix space tokens being dropped from stream preview.

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -79,6 +79,7 @@ var rs_close;
 var seqselmenu;
 var seqselcontents;
 var stream_preview;
+var stream_preview_text;
 var token_prob_container;
 
 var storyname = null;
@@ -2151,6 +2152,7 @@ function endStream() {
 	if (stream_preview) {
 		stream_preview.remove();
 		stream_preview = null;
+		stream_preview_text = null;
 	}
 }
 
@@ -2390,10 +2392,14 @@ $(document).ready(function(){
 			if (!stream_preview && streamingEnabled) {
 				stream_preview = document.createElement("span");
 				game_text.append(stream_preview);
+				stream_preview_text = "";
 			}
 
 			for (const token of msg.data) {
-				if (streamingEnabled) stream_preview.innerText += token.decoded;
+				if (streamingEnabled) {
+					stream_preview_text += token.decoded;
+					stream_preview.innerText = stream_preview_text;
+				}
 
 				if (probabilitiesEnabled) {
 					// Probability display


### PR DESCRIPTION
When streaming preview tokens arrive, they are accumulated into a stream_preview span.  These tokens were inserted one-by-one into the `innerText` property of this span.  However, the behavior of innerText is to discard trailing whitespace, which meant that a token that was entirely composed of spaces would be discarded.

See this link for more information on this behavior:
https://stackoverflow.com/questions/47768523/empty-spaces-are-ignored-by-the-innertext-property

I tried fixing this by switching to use `textContent`, however this caused newlines to be discarded instead.  This change fixes the issue by accumulating incoming tokens into a string and then assigning the string to innerText.