### PR TITLE
Better club importing

### DIFF
--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -2492,7 +2492,7 @@ body {
 	right: 0px;
 	height: calc(100vh - 15px);
 	width: 400px;
-	z-index: 8;
+	z-index: 99999999;
 	pointer-events: none;
 	overflow-y: hidden;
 	overflow-x: hidden;
@@ -2500,7 +2500,6 @@ body {
 }
 
 .notification {
-	z-index: 8;
 	background-color: #30414e;
 	animation: 10s 1 alternate swoosh-in;
 	margin-right: 15px;

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -4900,6 +4900,7 @@ function updateTitle() {
 }
 
 function openClubImport() {
+	$el("#aidgpromptnum").value = "";
 	openPopup("aidg-import-popup");
 }
 
@@ -5737,3 +5738,26 @@ function deleteConfirmation(sFormatted, confirmText, denyText, confirmCallback, 
 
 	openPopup("confirm-delete-dialog");
 }
+
+function attemptClubLoad() {
+	const input = $el("#aidgpromptnum");
+	let val = input.value;
+	if (!/^\d+$/.test(val)) {
+		// Not an id, is it a full URL?
+		const matches = val.match(/aetherroom\.club\/([0-9]+)/)
+		if (!matches) {
+			reportError("Malformed club import", "That doesn't look like a valid club URL or ID. Please check your input and try again.");
+			return;
+		}
+		val = matches[1];
+	}
+	socket.emit("load_aidg_club", val);
+	closePopups();
+}
+
+
+$el("#aidgpromptnum").addEventListener("keydown", function(event) {
+	if (event.key !== "Enter") return;
+	attemptClubLoad();
+	event.preventDefault();
+});

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -4922,6 +4922,12 @@ function openPopup(id) {
 
 	const popup = $el(`#${id}`);
 	popup.classList.remove("hidden");
+
+	// Sometimes we want to instantly focus on certain elements when a menu opens.
+	for (const noticeMee of popup.getElementsByClassName("focus-on-me")) {
+		noticeMee.focus();
+		break;
+	}
 }
 
 function closePopups() {

--- a/templates/popups.html
+++ b/templates/popups.html
@@ -122,10 +122,10 @@
 			<br/>
 			<div style="text-align: center;"><a href="https://aetherroom.club/" target="_blank" rel="noopener noreferrer">https://aetherroom.club/</a></div>
 			<br/>
-			<input autocomplete="off" class="form-control" type="text" placeholder="Prompt Number (4-digit number at the end of aetherroom.club URL)" id="aidgpromptnum">
+			<input autocomplete="off" class="form-control focus-on-me" type="text" placeholder="Prompt ID or URL" id="aidgpromptnum">
 		</div>
 		<div class="popup_load_cancel">
-			<button type="button" class="btn btn-primary popup_load_cancel_button" onclick="socket.emit('load_aidg_club', document.getElementById('aidgpromptnum').value);closePopups();">Accept</button>
+			<button type="button" class="btn btn-primary popup_load_cancel_button" onclick="attemptClubLoad();">Accept</button>
 			<button type="button" class="btn btn-primary popup_load_cancel_button" onclick="closePopups();">Cancel</button>
 		</div>
 	</div>


### PR DESCRIPTION
A bunch of small changes to club importing to just make it a little bit nicer
- id field autofocuses (you can also now use the `focus-on-me` class in any popup to autofocus an element)
- pressing enter on the id field now clicks accept
- we now accept the actual club url instead of id
- bad inputs are immediately rejected instead of sent along to inevitably receive a 404