### PR TITLE
Re-enable and fix several issues with phrase bias

### DIFF
--- a/templates/templates.html
+++ b/templates/templates.html
@@ -78,13 +78,13 @@
 	<div class="bias_score">
 		<div class="bias_slider">
 			<div class="bias_slider_bar">
-				<input type="range" min="-12" max="12" step="0.01" value="0" class="setting_item_input" 
+				<input type="range" min="-50" max="50" step="0.01" value="0" class="setting_item_input" 
 					oninput="update_bias_slider_value(this);"
 					onchange="save_bias(this);"/>
 			</div>
-			<div class="bias_slider_min">-12</div>
+			<div class="bias_slider_min">-50</div>
 			<div class="bias_slider_cur">0</div>
-			<div class="bias_slider_max">12</div>
+			<div class="bias_slider_max">50</div>
 		</div>
 	</div>
 	<div class="bias_comp_threshold">


### PR DESCRIPTION
Add the PhraseBiasLogitsProcessor to the logits processor list

Fix an issue with bias phrases that contain the start token multiple times.  Because we were searching backwards for the first occurrence of the start token, we would restart the phrase when we encountered a subsequent instance of the token.  We now search forwards from the maximum possible overlap to find the maximum overlap.

Fix an issue with the phrase bias token index not accounting for non-matching words.  Previously, once we found the start token, we would apply the bias for each token in the bias phrase even if subsequent tokens in the context didn't match the bias phrase.

Do not apply phrase completion if the bias score is negative.

If multiple phrases apply a score modifier to the same token, add the scores rather than replacing the modifier with the last occurrence.

Increase the maximum range of the bias slider.  For extremely repetitive text on large models, -12 is insufficient to break the model out of its loop.  -50 to 50 is potentially excessive, but it's safer to give the user some additional control over the bias score.