### PR TITLE
Basic Contrastive Search support for GPUs

### DIFF
--- a/gensettings.py
+++ b/gensettings.py
@@ -108,6 +108,21 @@ gensettingstf = [
 	{
 	"uitype": "slider",
 	"unit": "float",
+	"label": "Penalty Alpha",
+	"id": "setpenaltyalpha", 
+	"min": 0.0,
+	"max": 1.0,
+	"step": 0.01,
+	"default": 0.0,
+    "tooltip": "Alternative search method. Encourages diversity of output embeddings. To be used with Top-K. Does not work on TPU! (Put this value on 0 to disable its effect)",
+    "menu_path": "Settings",
+    "sub_path":  "Sampling",
+    "classname": "model",
+    "name": "penalty_alpha"
+	},
+	{
+	"uitype": "slider",
+	"unit": "float",
 	"label": "Repetition Penalty",
 	"id": "setreppen", 
 	"min": 1.0,

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -618,6 +618,7 @@ class model_settings(settings):
         self.top_a       = 0.0     # Default generator top-a
         self.tfs         = 1.0     # Default generator tfs (tail-free sampling)
         self.typical     = 1.0     # Default generator typical sampling threshold
+        self.penalty_alpha = 0.0   # Default generator penalty_alpha (contrastive search)
         self.numseqs     = 1       # Number of sequences to ask the generator to create
         self.badwordsids = []
         self.fp32_model  = False  # Whether or not the most recently loaded HF model was in fp32 format

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.20.1
+transformers>=4.24.0
 Flask
 Flask-SocketIO
 requests

--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -5,7 +5,7 @@ requests
 dm-haiku == 0.0.5
 jax == 0.2.21
 jaxlib >= 0.1.69, <= 0.3.7
-transformers >=4.20.1
+transformers >=4.24.0
 progressbar2
 git+https://github.com/VE-FORBRYDERNE/mesh-transformer-jax@ck
 flask

--- a/static/application.js
+++ b/static/application.js
@@ -2619,6 +2619,10 @@ $(document).ready(function(){
 			// Send current top a value to input
 			$("#settopacur").val(msg.data);
 			$("#settopa").val(parseFloat(msg.data)).trigger("change");
+		} else if(msg.cmd == "updatepenaltyalpha") {
+			// Send current top p value to input
+			$("#setpenaltyalphacur").val(msg.data);
+			$("#setpenaltyalpha").val(parseFloat(msg.data)).trigger("change");
 		} else if(msg.cmd == "updatereppen") {
 			// Send current rep pen value to input
 			$("#setreppencur").val(msg.data);
@@ -2649,6 +2653,9 @@ $(document).ready(function(){
 		} else if(msg.cmd == "setlabeltopp") {
 			// Update setting label with value from server
 			$("#settoppcur").val(msg.data);
+		} else if(msg.cmd == "setlabelpenaltyalpha") {
+			// Update setting label with value from server
+			$("#setpenaltyalphacur").val(msg.data);
 		} else if(msg.cmd == "setlabeltopk") {
 			// Update setting label with value from server
 			$("#settopkcur").val(msg.data);


### PR DESCRIPTION
Users must upgrade transformers to make use of contrastive search, and TPUs cannot use it until we have an in-house implementation.